### PR TITLE
Some differences between Centos 8 and Centos 7 when compiling

### DIFF
--- a/assess-tuning/dtn_tune.c
+++ b/assess-tuning/dtn_tune.c
@@ -4,10 +4,16 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-#include <bits/stdint-uintn.h>
+//#include <bits/stdint-uintn.h>
 #include <ctype.h>
 #include <getopt.h>
 #include <time.h>
+
+
+#ifndef  uint32_t
+typedef unsigned int uint32_t;
+#endif
+
 #define WORKFLOW_NAMES_MAX	4
 
 


### PR DESCRIPTION
Include file differences between the 2 systems in particular:
make
cc -Wall   -o dtn_tune \
 dtn_tune.c
dtn_tune.c:7:31: fatal error: bits/stdint-uintn.h: No such file or directory
 #include <bits/stdint-uintn.h>
                               ^
compilation terminated.
make: *** [dtn_tune] Error 1