### PR TITLE
small change to user default values

### DIFF
--- a/assess-tuning/user_config.txt
+++ b/assess-tuning/user_config.txt
@@ -1,4 +1,4 @@
-evaluation_timer		n	
+evaluation_timer		2	
 learning_mode_only		y
 API_listen_port			5523
 apply_bios_tuning		n


### PR DESCRIPTION
evaluation_timer had a non numeric value in the .txt file