### PR TITLE
Work on ksoftirqd (#86)

### DIFF
--- a/userspace/user_dtn.h
+++ b/userspace/user_dtn.h
@@ -52,6 +52,16 @@ extern void fDoNicTuning(void);
 extern void fDoSystemtuning(void);
 extern void fDo_lshw(void);
 extern void fCheck_log_limit(void);
+extern int fDoGetNproc(void);
+extern int nProc;
+
+extern int netDevice_rx_channel_cfg_max_val;
+extern int netDevice_tx_channel_cfg_max_val;
+extern int netDevice_combined_channel_cfg_max_val;
+extern int netDevice_rx_channel_cfg_curr_val;
+extern int netDevice_tx_channel_cfg_curr_val;
+extern int netDevice_combined_channel_cfg_curr_val;
+extern int netDevice_only_combined_channel_cfg;
 
 extern void Pthread_mutex_lock(pthread_mutex_t *);
 extern void Pthread_mutex_unlock(pthread_mutex_t *);


### PR DESCRIPTION
* ksoftirqd fixes
* Fixed the issue when the kernel thread  "ksoftirqd" has a high CPU usage (> 60% in our case) when using the Netronome NIC. However,  when using the Mellanox NIC, was not able to reliably lower the usage when the issue occurs. Tried setting complete IRQ affinity (RSS) and various commands using ethtool -L and ethtool -X using weights and combinations. Perhaps the problem is with the driver or firmware of the card or with the version of Linux kernel that we are using. Will revisit using Mellanox at a later date. 